### PR TITLE
Update the pina-golada version from 1.4.0 to 1.4.1

### DIFF
--- a/HomebrewFormula/pina-golada.rb
+++ b/HomebrewFormula/pina-golada.rb
@@ -1,9 +1,9 @@
 class PinaGolada < Formula
   desc "pina-golada - a simple asset tool for go, which generates interface implementations that provide files/folders in the final build, without rendering them in the source code themselve"
   homepage "https://github.com/homeport/pina-golada"
-  url "https://github.com/homeport/pina-golada/releases/download/v1.4.0/pina-golada-darwin-amd64"
-  version "v1.4.0"
-  sha256 "35b69e94f058aa178052ef7ad02a16a0ba639727f98b7a69b5c8b19582edacc9"
+  url "https://github.com/homeport/pina-golada/releases/download/v1.4.1/pina-golada-darwin-amd64"
+  version "v1.4.1"
+  sha256 "41d3cbde1670d04eb711e7385e643a23ffddf35bc6136cd10fd6e3564da635aa"
 
   def install
     mv('pina-golada-darwin-amd64', 'pina-golada')


### PR DESCRIPTION
This commit updates the homebrew latest release of the pina-golada
project to the currently latest available version of pina-golada on
github: 1.4.1.