### PR TITLE
feat: allow amd64 binaries of pd, gonut & yft to install on M1

### DIFF
--- a/HomebrewFormula/gonut.rb
+++ b/HomebrewFormula/gonut.rb
@@ -9,13 +9,11 @@ class Gonut < Formula
   license "MIT"
 
   on_macos do
-    if Hardware::CPU.intel?
-      url "https://github.com/homeport/gonut/releases/download/v2.0.4/gonut_2.0.4_darwin_amd64.tar.gz", :using => CurlDownloadStrategy
-      sha256 "c456e5c7cf76946df4c0b7c1ead4c8fe31bc2207c702d7e83f763034c962a8aa"
+    url "https://github.com/homeport/gonut/releases/download/v2.0.4/gonut_2.0.4_darwin_amd64.tar.gz", :using => CurlDownloadStrategy
+    sha256 "c456e5c7cf76946df4c0b7c1ead4c8fe31bc2207c702d7e83f763034c962a8aa"
 
-      def install
-        bin.install "gonut"
-      end
+    def install
+      bin.install "gonut"
     end
   end
 

--- a/HomebrewFormula/pd.rb
+++ b/HomebrewFormula/pd.rb
@@ -9,13 +9,11 @@ class Pd < Formula
   license "MIT"
 
   on_macos do
-    if Hardware::CPU.intel?
-      url "https://github.com/homeport/pd/releases/download/v2.5.4/pd_2.5.4_darwin_amd64.tar.gz", :using => CurlDownloadStrategy
-      sha256 "fdbd94bfebf2b55c48ae4aa09f5b50cb51578008bb972914f73b2985b63b7264"
+    url "https://github.com/homeport/pd/releases/download/v2.5.4/pd_2.5.4_darwin_amd64.tar.gz", :using => CurlDownloadStrategy
+    sha256 "fdbd94bfebf2b55c48ae4aa09f5b50cb51578008bb972914f73b2985b63b7264"
 
-      def install
-        bin.install "pd"
-      end
+    def install
+      bin.install "pd"
     end
   end
 

--- a/HomebrewFormula/yft.rb
+++ b/HomebrewFormula/yft.rb
@@ -9,13 +9,11 @@ class Yft < Formula
   license "MIT"
 
   on_macos do
-    if Hardware::CPU.intel?
-      url "https://github.com/homeport/yft/releases/download/v1.0.5/yft_1.0.5_darwin_amd64.tar.gz", :using => CurlDownloadStrategy
-      sha256 "2371f3181054de3af90227c181e8deedcd7ca458d6116e4e069aafcfacc98a94"
+    url "https://github.com/homeport/yft/releases/download/v1.0.5/yft_1.0.5_darwin_amd64.tar.gz", :using => CurlDownloadStrategy
+    sha256 "2371f3181054de3af90227c181e8deedcd7ca458d6116e4e069aafcfacc98a94"
 
-      def install
-        bin.install "yft"
-      end
+    def install
+      bin.install "yft"
     end
   end
 


### PR DESCRIPTION
M1 Macs come with Rosetta emulation which is able to run binaries
built for amd64. This of course impacts the performance but
until native binaries are built this would help unblock installation
of other binaries on M1.

Without this brew tap homeport/tap fails because there is not url
for pd/yft/gonut.

Fixes: https://github.com/homeport/homebrew-tap/issues/52